### PR TITLE
(SIMP-6110) Use (namespaced) simplib::passgen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
-  - gem install -v '~> 1.16.0' bundler
+  - gem install -v '~> 1.17' bundler
 
 global:
   - STRICT_VARIABLES=yes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 * Mon Jan 07 2019 Liz Nemsick <lnemsick-simp@gmail.com> - 0.1.1
 - Confine tpm2 fact on the presence of TPM 2 tools required
   for that fact evaluation
+- Use simplib::passgen() in lieu of passgen(), a deprecated simplib
+  Puppet 3 function.
 
 * Wed Nov 21 2018 Adam Yohrling <adam.yohrling@onyxpoint.com> - 0.1.0
 - Added OEL support

--- a/manifests/ownership.pp
+++ b/manifests/ownership.pp
@@ -42,9 +42,9 @@ class tpm2::ownership(
   Enum['set','clear']            $owner              = 'clear',
   Enum['set','clear']            $endorsement        = 'clear',
   Enum['set','clear']            $lockout            = 'clear',
-  String[14]                     $owner_auth         = passgen("${facts['fqdn']}_tpm_owner_auth", {'length'=> 24}),
-  String[14]                     $lockout_auth       = passgen("${facts['fqdn']}_tpm_lock_auth", {'length'=> 24}),
-  String[14]                     $endorsement_auth   = passgen("${facts['fqdn']}_tpm_endorse_auth", {'length'=> 24}),
+  String[14]                     $owner_auth         = simplib::passgen("${facts['fqdn']}_tpm_owner_auth", {'length'=> 24}),
+  String[14]                     $lockout_auth       = simplib::passgen("${facts['fqdn']}_tpm_lock_auth", {'length'=> 24}),
+  String[14]                     $endorsement_auth   = simplib::passgen("${facts['fqdn']}_tpm_endorse_auth", {'length'=> 24}),
   Boolean                        $in_hex             = false,
   String                         $service_name       = $tpm2::tabrm_service
 ){

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
   "dependencies": [
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.3.1 < 4.0.0"
+      "version_requirement": ">= 3.5.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
Use simplib::passgen() in lieu of passgen(), a deprecated simplib
Puppet 3 function.

SIMP-6110 #comment pupmod-simp-tpm2