### PR TITLE
(SIMP-6229) Update upper bound stdlib < 6.0.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,14 +1,8 @@
 ---
 fixtures:
   repositories:
-    iptables:
-      repo: https://github.com/simp/pupmod-simp-iptables
-      ref: 6.0.1
-    simplib:
-      repo: https://github.com/simp/pupmod-simp-simplib
-      ref: 3.9.1
-    stdlib:
-      repo: https://github.com/simp/puppetlabs-stdlib
-      ref: 4.13.1
+    iptables: https://github.com/simp/pupmod-simp-iptables
+    simplib: https://github.com/simp/pupmod-simp-simplib
+    stdlib: https://github.com/simp/puppetlabs-stdlib
   symlinks:
     tpm2: "#{source_dir}"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@
   for that fact evaluation
 - Use simplib::passgen() in lieu of passgen(), a deprecated simplib
   Puppet 3 function.
+- Update the upper bound of stdlib to < 6.0.0
+- Update a URL in the README.md
 
 * Wed Nov 21 2018 Adam Yohrling <adam.yohrling@onyxpoint.com> - 0.1.0
 - Added OEL support

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ See [REFERENCE.md](REFERENCE.md) for API documentation.
 
 ## Development
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 ### Acceptance tests
 
@@ -137,7 +137,7 @@ hosted at https://github.com/op-ct/simp-tpm2-rpms/releases.
 Please refer to the [SIMP Beaker Helpers documentation](https://github.com/simp/rubygem-simp-beaker-helpers/blob/master/README.md)
 for more information.
 
-[simp]: https://github.com/NationalSecurityAgency/SIMP
+[simp]: https://simp-project.com
 [simp-bug-tracker]: https://simp-project.atlassian.net/
 [tpm2-tools]: https://github.com/tpm2-software/tpm2-toolso
 [tpm2-software]: https://github.com/tpm2-software/

--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
- Update the upper bound of stdlib to < 6.0.0
- Update a URL in the README.md

SIMP-6229 #comment pupmod-simp-tmp2