### PR TITLE
Removes puppet 6 from .gitlab-ci.yml

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -27,7 +27,7 @@ on:
     types: [opened, reopened, synchronize]
 
 env:
-  PUPPET_VERSION: '~> 6'
+  PUPPET_VERSION: '~> 7'
 
 jobs:
   puppet-syntax:
@@ -38,7 +38,7 @@ jobs:
       - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
         uses: ruby/setup-ruby@v1  # ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: "bundle exec rake syntax"
 
@@ -50,7 +50,7 @@ jobs:
       - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: "bundle exec rake lint"
       - run: "bundle exec rake metadata_lint"
@@ -65,7 +65,7 @@ jobs:
       - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: |
           bundle show
@@ -76,10 +76,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: 'Install Ruby 2.5'
+      - name: 'Install Ruby 2.7'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: bundle exec rake check:dot_underscore
       - run: bundle exec rake check:test_file
@@ -92,7 +92,7 @@ jobs:
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - name: 'Tags and changelogs'
         run: |
@@ -109,12 +109,12 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 6.22 [SIMP 6.6/PE 2019.8]'
-            puppet_version: '~> 6.22.1'
-            ruby_version: '2.5'
           - label: 'Puppet 7.x'
-            puppet_version: '~> 7.0'
+            puppet_version: '~> 7.21.0'
             ruby_version: '2.7'
+          - label: 'Puppet 8.x'
+            puppet_version: '~> 8.0'
+            ruby_version: '3.2'
     env:
       PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -340,9 +340,9 @@ pup7.pe-unit:
   <<: *pup_7_pe
   <<: *unit_tests
 
-pup8.x-unit:
-  <<: *pup_8_x
-  <<: *unit_tests
+#pup8.x-unit:
+#  <<: *pup_8_x
+#  <<: *unit_tests
 
 # ------------------------------------------------------------------------------
 #             NOTICE: **This file is maintained with puppetsync**
@@ -391,8 +391,8 @@ pup7.pe-oel-fips:
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
 
-pup8.x:
-  <<: *pup_8_x
-  <<: *acceptance_base
-  script:
-    - 'bundle exec rake beaker:suites[default,default]'
+#pup8.x:
+#  <<: *pup_8_x
+#  <<: *acceptance_base
+#  script:
+#    - 'bundle exec rake beaker:suites[default,default]'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -232,26 +232,26 @@ variables:
 # Puppet Versions
 #-----------------------------------------------------------------------
 
-.pup_6_x: &pup_6_x
-  image: 'ruby:2.5'
-  variables:
-    PUPPET_VERSION: '~> 6.0'
-    BEAKER_PUPPET_COLLECTION: 'puppet6'
-    MATRIX_RUBY_VERSION: '2.5'
-
-.pup_6_pe: &pup_6_pe
-  image: 'ruby:2.5'
-  variables:
-    PUPPET_VERSION: '6.22.1'
-    BEAKER_PUPPET_COLLECTION: 'puppet6'
-    MATRIX_RUBY_VERSION: '2.5'
-
 .pup_7_x: &pup_7_x
   image: 'ruby:2.7'
   variables:
     PUPPET_VERSION: '~> 7.0'
     BEAKER_PUPPET_COLLECTION: 'puppet7'
     MATRIX_RUBY_VERSION: '2.7'
+
+.pup_7_pe: &pup_7_pe
+  image: 'ruby:2.7'
+  variables:
+    PUPPET_VERSION: '7.21.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet7'
+    MATRIX_RUBY_VERSION: '2.7'
+
+.pup_8_x: &pup_8_x
+  image: 'ruby:3.2'
+  variables:
+    PUPPET_VERSION: '~> 8.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet8'
+    MATRIX_RUBY_VERSION: '3.2'
 
 
 
@@ -302,7 +302,7 @@ variables:
 #=======================================================================
 
 releng_checks:
-  <<: *pup_6_x
+  <<: *pup_7_x
   <<: *setup_bundler_env
   stage: 'validation'
   tags: ['docker']
@@ -325,23 +325,23 @@ releng_checks:
 #       different Puppet versions won't accomplish anything.
 
 pup-lint:
-  <<: *pup_6_x
+  <<: *pup_7_x
   <<: *lint_tests
 
 # Unit Tests
 #-----------------------------------------------------------------------
 
-pup6.x-unit:
-  <<: *pup_6_x
+pup7.x-unit:
+  <<: *pup_7_x
   <<: *unit_tests
   <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
-pup6.pe-unit:
-  <<: *pup_6_pe
+pup7.pe-unit:
+  <<: *pup_7_pe
   <<: *unit_tests
 
-pup7.x-unit:
-  <<: *pup_7_x
+pup8.x-unit:
+  <<: *pup_8_x
   <<: *unit_tests
 
 # ------------------------------------------------------------------------------
@@ -354,45 +354,45 @@ pup7.x-unit:
 # Repo-specific content
 # ==============================================================================
 
-pup6.x:
-  <<: *pup_6_x
+pup7.x:
+  <<: *pup_7_x
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,default]'
 
-pup6.x-fips:
-  <<: *pup_6_x
+pup7.x-fips:
+  <<: *pup_7_x
   <<: *acceptance_base
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'
 
-pup6.pe:
-  <<: *pup_6_pe
+pup7.pe:
+  <<: *pup_7_pe
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,default]'
 
-pup6.pe-fips:
-  <<: *pup_6_pe
+pup7.pe-fips:
+  <<: *pup_7_pe
   <<: *acceptance_base
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'
 
-pup6.pe-oel:
-  <<: *pup_6_pe
+pup7.pe-oel:
+  <<: *pup_7_pe
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,oel]'
 
-pup6.pe-oel-fips:
-  <<: *pup_6_pe
+pup7.pe-oel-fips:
+  <<: *pup_7_pe
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
 
-pup7.x:
-  <<: *pup_7_x
+pup8.x:
+  <<: *pup_8_x
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,default]'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  puppet_version = ENV['PUPPET_VERSION'] || '~> 6.22'
+  puppet_version = ENV['PUPPET_VERSION'] || '~> 7'
   major_puppet_version = puppet_version.scan(/(\d+)(?:\.|\Z)/).flatten.first.to_i
   gem 'rake'
   gem 'puppet', puppet_version

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -1,42 +1,32 @@
-<%
-  if ENV['BEAKER_HYPERVISOR']
-    hypervisor = ENV['BEAKER_HYPERVISOR']
-  else
-    hypervisor = 'vagrant'
-  end
--%>
 ---
 HOSTS:
   oel7:
     roles:
-      - default
-    platform:   el-7-x86_64
-    box:        generic/oracle7
-    hypervisor: <%= hypervisor %>
+    - default
+    platform: el-7-x86_64
+    box: generic/oracle7
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
     yum_repos:
       simp_unstable:
-        baseurl: 'https://download.simp-project.com/simp/yum/rolling/6/el/$releasever/$basearch/simp/'
+        baseurl: https://download.simp-project.com/simp/yum/rolling/6/el/$releasever/$basearch/simp/
         gpgcheck: 0
-
+    family: sicura-image-build/oracle-linux-7
+    gce_machine_type: n1-standard-2
   oel8:
-    platform:   el-8-x86_64
-    box:        generic/oracle8
-    hypervisor: <%= hypervisor %>
+    platform: el-8-x86_64
+    box: generic/oracle8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
     yum_repos:
-      # The TPM2 simulator RPMs are currently in the unstable repositories
       simp_unstable:
-        baseurl: 'https://download.simp-project.com/simp/yum/unstable/6/el/$releasever/$basearch/simp/'
+        baseurl: https://download.simp-project.com/simp/yum/unstable/6/el/$releasever/$basearch/simp/
         gpgcheck: 0
-
+    family: sicura-image-build/oracle-linux-8
+    gce_machine_type: n1-standard-2
 CONFIG:
   log_level: verbose
-  type:      aio
+  type: aio
   vagrant_memsize: 512
   synced_folder: enabled
   ssh:
     timeout: 2
-
-<% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
-  puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
-<% end -%>
-# vb_gui: true
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet7') %>"


### PR DESCRIPTION
This patch moves puppet 6 refs to 7, puppet 7 refs to 8. Then we manually
update all spec nodesets to point to sicura oel boxes and comment out all 
pup8 tests.

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.