### PR TITLE
Allow tpm2_getcap version to be missing patchlevel

### DIFF
--- a/lib/facter/tpm2/util.rb
+++ b/lib/facter/tpm2/util.rb
@@ -26,7 +26,7 @@ class Facter::TPM2::Util
     # Between versions the options for 'tpm2_getcap' changed. Determine the
     # version and set the options.
     output = Facter::Core::Execution.execute(%(#{cmd} -v))
-    if output =~ /version="(\d+\.\d+\.\d+)/
+    if output =~ /version="(\d+\.\d+(\.\d+)?)/
       @version = $1
 
       if Gem::Version.new(@version) < Gem::Version.new('4.0.0')


### PR DESCRIPTION
Make the module work even if `tpm2_getcap` doesn't have the full majver.minver.patchver (e.g. `5.2` instead of `5.2.2`) by making the patchlevel optional in the regex.

On Ubuntu 22.04 `tpm2_getcap` version is `5.2`